### PR TITLE
Make CORS origin configurable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ DB_USER=root
 DB_PASS=root
 DB_NAME=plataforma
 JWT_SECRET=supersecretkey
+CORS_ORIGIN=http://localhost:3000

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,8 +5,9 @@ import { AppModule }   from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // habilitar CORS para o frontend em localhost:3000
-  app.enableCors({ origin: 'http://localhost:3000', credentials: true });
+  const allowedOrigin = process.env.CORS_ORIGIN || 'http://localhost:3000';
+  // habilitar CORS a partir da origem configurada
+  app.enableCors({ origin: allowedOrigin, credentials: true });
 
   await app.listen(3001);
 }


### PR DESCRIPTION
## Summary
- allow specifying CORS origin via `CORS_ORIGIN` env variable
- document `CORS_ORIGIN` in `.env.example`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854ae5f4a6c8332a30c87fc85d85381