### PR TITLE
Fix build for Next.js frontend

### DIFF
--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -30,4 +30,5 @@ export default function Home() {
         </div>
       </main>
     </>
+  );
 }

--- a/frontend/src/components/DashboardHeader.tsx
+++ b/frontend/src/components/DashboardHeader.tsx
@@ -1,7 +1,7 @@
-export default function DashboardHeader() {
+export default function DashboardHeader({ userEmail }: { userEmail?: string }) {
   return (
     <div className="flex items-center justify-between mb-6">
-      <h2 className="text-2xl font-bold text-white">Olá, Usuário!</h2>
+      <h2 className="text-2xl font-bold text-white">Olá, {userEmail ?? 'Usuário'}!</h2>
       <p className="text-gray-400">Bem-vindo de volta à sua área</p>
     </div>
   );

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -24,23 +24,54 @@ export default function Dashboard() {
     { title: 'Próxima aula',         value: 'React Avançado - 25/05/2025' },
   ];
   const progressData = [
-    { name: 'Semana 1', value: 10 },
-    { name: 'Semana 2', value: 25 },
-    { name: 'Semana 3', value: 40 },
-    { name: 'Semana 4', value: 45 },
+    { curso: 'Semana 1', percentual: 10 },
+    { curso: 'Semana 2', percentual: 25 },
+    { curso: 'Semana 3', percentual: 40 },
+    { curso: 'Semana 4', percentual: 45 },
   ];
   const activities = [
-    { id: 1, title: 'Quiz de TypeScript', status: 'pendente' },
-    { id: 2, title: 'Exercício de Hooks',  status: 'concluído' },
-    { id: 3, title: 'Projeto Final',       status: 'em andamento' },
+    {
+      id:       1,
+      title:    'Quiz de TypeScript',
+      course:   'TypeScript Básico',
+      deadline: '2025-05-10',
+    },
+    {
+      id:       2,
+      title:    'Exercício de Hooks',
+      course:   'React Intermediário',
+      deadline: '2025-05-15',
+    },
+    {
+      id:       3,
+      title:    'Projeto Final',
+      course:   'React Avançado',
+      deadline: '2025-05-30',
+    },
   ];
   const ebooks = [
-    { id: 1, title: 'Guia React Avançado',   url: '/ebooks/react-avancado.pdf' },
-    { id: 2, title: 'TypeScript Essencial',  url: '/ebooks/typescript.pdf' },
+    {
+      id:       1,
+      title:    'Guia React Avançado',
+      coverUrl: '/ebooks/react-avancado.png',
+    },
+    {
+      id:       2,
+      title:    'TypeScript Essencial',
+      coverUrl: '/ebooks/typescript.png',
+    },
   ];
   const notifications = [
-    { id: 1, message: 'Nova aula disponível: Next.js Auth', date: '20/05/2025' },
-    { id: 2, message: 'Quiz corrigido com sucesso!',           date: '18/05/2025' },
+    {
+      id:        1,
+      message:   'Nova aula disponível: Next.js Auth',
+      timestamp: '2025-05-20',
+    },
+    {
+      id:        2,
+      message:   'Quiz corrigido com sucesso!',
+      timestamp: '2025-05-18',
+    },
   ];
 
   return (

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import NextAuth, { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    accessToken?: string;
+  }
+  interface User {
+    accessToken?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- fix React component return statement in `index.tsx`
- allow DashboardHeader to receive user email
- adjust dashboard mock data for type safety
- add NextAuth session extensions

## Testing
- `npm install` (frontend)
- `npm run build` (frontend)
- `npx vercel --prod` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68555dd0845883329b749259a090cc5b