### PR TITLE
Fix seed import path

### DIFF
--- a/backend/seed.ts
+++ b/backend/seed.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { AppDataSource } from './data-source';
-import { User } from '../backend/src/entities/user.entity';
+import { User } from './src/entities/user.entity';
 import * as bcrypt from 'bcrypt';
 
 async function seed() {


### PR DESCRIPTION
## Summary
- fix import path for the `User` entity in `backend/seed.ts`

## Testing
- `npm run seed` *(fails to connect to MySQL, confirming script runs)*

------
https://chatgpt.com/codex/tasks/task_e_685ed073b174833296bb191e5e6cb55e